### PR TITLE
Change Swarm url

### DIFF
--- a/index.html
+++ b/index.html
@@ -622,7 +622,7 @@ function update_tiny(i) {
    <h3>Decentralized storage</h3>
     <ul>
       <li><a href="https://ipfs.io/docs/" target="_blank">IPFS</a></li>
-      <li><a href="http://swarm-gateways.net/" target="_blank">Swarm</a></li> 
+      <li><a href="https://ethswarm.org/" target="_blank">Swarm</a></li> 
       <li><a href="https://github.com/orbitdb/orbit-db" target="_blank">Orbit</a></li>
     </ul>
   <p><a name="various"></a></p>


### PR DESCRIPTION
The `swarm-gateways.net` was the website for the gateway for the deprecated Swarm client. The current website can be found at `ethswarm.org`